### PR TITLE
Improve player strategy

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # wopr-tag
 Agent based simulation engine for playing tag
 
-## What is it
+## What is it (pun intended)
 wopr-tag is a simulation engine for the game of tag. The rules are as follows:
 - One and only one player is it at a time.
 - When a player is it and next to another player they may tag them and now the
@@ -16,8 +16,9 @@ wopr-tag is a simulation engine for the game of tag. The rules are as follows:
   are at the edge of the field of play and are surrounded by other players then
   they will take no action for that turn.
 - Two players cannot occupy the same space on the field.
-
-In the current version the players move randomly, in order, one at a time.
+- Players try to avoid moving closer to the it player. They are randomly
+  assigned a risk tolerance. The higher the tolerance the more likely their
+  random movements will move them closer to the it player.
 
 ## How to run
 wopr-tag is written in Rust, which is required to compile and run. If you do
@@ -34,6 +35,10 @@ field. The dimensions and players must be at least three. For example, to run
 the simulation with 3 players on a 4x4 field you would run `wopr_tag
 --num-players 3 --x-size 4 --y-size 4`.
 
+If you are in the project directory you can compile and run the application at
+the same time using the `cargo run` command.  For example: `cargo run --release
+--bin wopr_tag -- --num-players 10 --x-size 500 --y-size 500`
+
 ### Advanced options
 By default the field of play is displayed, but this can be turned off by
 including the `--show-field false` argument.
@@ -43,6 +48,38 @@ default is 250ms. This allows the user to view the field of play and any
 changes in who is it. To accelerate the simulation you can set this number as
 low as zero by including the `--wait-between-turn 0` argument.
 
+You can define the number of turns the simulation will take. To set it to
+100,000 you would pass the argument `--num-turns 100000`.
+
+There is some sparse debug logging available. You can set the environment
+variable `LOG_LEVEL` to `debug` for more verbose logging. For example:
+`LOG_LEVEL=debug wopr_tag --num-players 3 --x-size 4 --y-size 4`. The default
+is `INFO`.
+
+## Known limitations
+- The player who is it moves randomly. The realism of the simulation would
+  likely be improved if the currently it player attempted to move in a
+  direction towards the closet player or the most players.
+- Players do not face in a specific direction. Ideally a player would have a
+  certain orientation and they would only see other players in their line of
+  sight and would continue moving in a forward direction with a higher
+  probability.
+- Players all move at the same speed and have the same endurance. This can
+  easily be changed by assigning these attributes randomly during
+  initialization and allowing players to move more than once per turn and
+  forcing them to not move when they have no stamina.
+- The statistics output is very basic.
+- Only one player acts at a time, and the order in which players act is the
+  same for the entire simulation. This was an intentional trade-off for the
+  sake of achieving correctness and reliability first. Theoretically, the
+  individual player agents can run independently on their own threads. However,
+  you would need to refactor the `FieldOfPlay` cache to support a
+  multi-threaded approach.
+- Only one simulation runs at once. This is intentional since the viewer is so
+  basic, and there aren't a lot of parameters that would meaningfully change
+  the results. Assuming integration with a TUI crate it would be rather trivial
+  to then run multiple simulations at once using Rayon.
+
 ## Note on tests
 I've included some unit tests to show that I'm not uncivilized, but I made the
 conscious decision to not make them exhaustive. The simulation itself is not
@@ -50,4 +87,5 @@ tested becuse that would require complex setup beyond the scope of the project.
 The public functions of the agent and other models have basic tests, but not
 every logic condition is covered.
 
+## Namesake
 ![the original wopr](http://guidetomonsters.com/img/eighties/Wop1.jpg)

--- a/src/bin/cli/wopr_tag.rs
+++ b/src/bin/cli/wopr_tag.rs
@@ -71,6 +71,17 @@ fn process_command_line() {
                 .default_value("250")
                 .validator(validate_wait)
         )
+        .arg(
+            Arg::with_name("num_turns")
+                .value_name("num_turns")
+                .help("how many turns players get to take")
+                .short("t")
+                .long("num-turns")
+                .required(false)
+                .takes_value(true)
+                .default_value("1000")
+                .validator(validate_num_turns)
+        )
         .get_matches();
 
     // Unwrapping here is safe because we have already validated the inputs via Clap's
@@ -80,10 +91,11 @@ fn process_command_line() {
     let y_size = matches.value_of("y_size").unwrap().parse::<usize>().unwrap();
     let wait = matches.value_of("wait_between_turn").unwrap().parse::<u64>().unwrap();
     let show_field = matches.value_of("show_field").unwrap().parse::<bool>().unwrap();
+    let num_turns = matches.value_of("num_turns").unwrap().parse::<usize>().unwrap();
 
     debug!(
-        "cli args - number_of_players: {}, x_size: {}, y_size: {}",
-        num_players, x_size, y_size
+        "cli args - number_of_players: {}, x_size: {}, y_size: {}, wait: {}, show_field: {}, num_turns: {}",
+        num_players, x_size, y_size, wait, show_field, num_turns
     );
 
     if x_size * y_size < num_players {
@@ -92,7 +104,7 @@ fn process_command_line() {
             num_players, x_size, y_size
         );
     } else {
-        wopr_tag::init(num_players, x_size, y_size, wait, show_field);
+        wopr_tag::init(num_players, x_size, y_size, wait, show_field, num_turns);
     }
 }
 
@@ -149,4 +161,21 @@ fn validate_bool(bool_str: String) -> Result<(), String> {
     }
 
     Err("Value must be true or false".to_owned())
+}
+
+fn validate_num_turns(turns: String) -> Result<(), String> {
+    let turns_parse_result = turns.parse::<usize>();
+
+    if let Ok(turns) = turns_parse_result {
+        if turns >= 10 {
+            return Ok(());
+        }
+    };
+
+    let err_msg = format!(
+        "the number of turns must be a valid integer between 10 - {} inclusive.",
+        usize::MAX
+    );
+
+    Err(err_msg)
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -57,6 +57,10 @@ fn players_take_action(field_of_play_cache: &mut FieldOfPlay, players: &mut Vec<
             .expect("Invalid player index when attempting to take action.");
         let player_name = player.name.to_owned();
         let (old_x, old_y) = player.get_location();
+        // We only set the last known it location here, instead of also when a new player is tagged
+        // to simulate a non-zero reaction time from the other players with regards to knowing who
+        // is it.
+        field_of_play_cache.set_last_known_it_location(old_x, old_y);
         let actions = player.take_action(&field_of_play_cache, *last_it_index);
         debug!(
             "player at index: {} is acting. old_x: {}, old_y: {}, actions: {:?}",

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,7 +8,14 @@ use std::{thread, time};
 
 // If this were a real project we would test the actual simulation somehow. But that would eat up
 // quite a bit of time.
-pub fn init(num_players: usize, x_axis_len: usize, y_axis_len: usize, wait_between_turn_ms: u64, show_field: bool) {
+pub fn init(
+    num_players: usize,
+    x_axis_len: usize,
+    y_axis_len: usize,
+    wait_between_turn_ms: u64,
+    show_field: bool,
+    num_turns: usize
+) {
     info!(
         "Initalizing game with num players: {}, x-axis size: {}, y-axis size: {}",
         num_players, x_axis_len, y_axis_len
@@ -24,19 +31,20 @@ pub fn init(num_players: usize, x_axis_len: usize, y_axis_len: usize, wait_betwe
         players.push(player);
     });
 
-    simulate(field_of_play, players, wait_between_turn_ms, show_field);
+    simulate(field_of_play, players, wait_between_turn_ms, show_field, num_turns);
 }
 
 fn simulate(
     mut field_of_play_cache: FieldOfPlay,
     mut players: Vec<Player>,
     wait_between_turn_ms: u64,
-    show_field: bool
+    show_field: bool,
+    num_turns: usize
 ) {
     let sleep_between_turn_dur = time::Duration::from_millis(wait_between_turn_ms);
     let mut last_it_index = 0;
     let mut turn_num = 0;
-    loop {
+    while turn_num < num_turns {
         turn_num += 1;
         players_take_action(&mut field_of_play_cache, &mut players, &mut last_it_index);
 

--- a/src/models/field_of_play.rs
+++ b/src/models/field_of_play.rs
@@ -8,7 +8,8 @@ static GENERIC_VEC_ACCESS_PANIC_ERR_MSG: &str = "Invalid field index.";
 
 #[derive(Debug)]
 pub struct FieldOfPlay {
-    pub field: Field
+    pub field: Field,
+    last_known_it_coordinates: Option<(usize, usize)>
 }
 
 #[derive(Default)]
@@ -31,7 +32,10 @@ impl FieldOfPlay {
             field_of_play.push(x_vec);
         });
 
-        FieldOfPlay { field: field_of_play }
+        FieldOfPlay {
+            field: field_of_play,
+            last_known_it_coordinates: None
+        }
     }
 
     /// Returns a vec of player indices that are adjacent to the input coordinates. This can be
@@ -90,6 +94,14 @@ impl FieldOfPlay {
             Direction::SouthWest => self.is_position_valid_and_get_occupant_south_west(x, y).can_move_to(),
             Direction::West => self.is_position_valid_and_get_occupant_west(x, y).can_move_to()
         }
+    }
+
+    pub fn set_last_known_it_location(&mut self, x: usize, y: usize) {
+        self.last_known_it_coordinates = Some((x, y));
+    }
+
+    pub fn get_last_known_it_location(&self) -> Option<(usize, usize)> {
+        self.last_known_it_coordinates
     }
 
     fn is_position_valid_and_get_occupant_south(&self, x: usize, y: usize) -> PositionDetails {
@@ -298,4 +310,12 @@ fn field_is_position_valid_and_empty_test() {
     assert!(field_of_play.is_position_valid_and_empty(Direction::NorthWest, 1, 1));
     assert!(field_of_play.is_position_valid_and_empty(Direction::SouthEast, 1, 1));
     assert!(field_of_play.is_position_valid_and_empty(Direction::SouthWest, 1, 1));
+}
+
+#[test]
+fn field_last_known_it_position_test() {
+    let mut field_of_play = FieldOfPlay::new(3, 3);
+    assert_eq!(field_of_play.get_last_known_it_location(), None);
+    field_of_play.set_last_known_it_location(3, 4);
+    assert_eq!(field_of_play.get_last_known_it_location(), Some((3, 4)));
 }

--- a/src/models/mod.rs
+++ b/src/models/mod.rs
@@ -2,3 +2,4 @@ pub mod action;
 pub mod direction;
 pub mod field_of_play;
 pub mod player;
+pub mod stats;

--- a/src/models/player.rs
+++ b/src/models/player.rs
@@ -57,6 +57,10 @@ impl Player {
         }
     }
 
+    pub fn get_risk_tolerance(&self) -> f64 {
+        self.risk_tolerance
+    }
+
     /// Looks at the field of play and takes at least one action. If the player is not it, it will
     /// attempt to move. If the player is it, it will attempt to tag any nearby players and also
     /// move. The tag action will only occur before the move action. If a player is it, does not

--- a/src/models/player.rs
+++ b/src/models/player.rs
@@ -1,7 +1,7 @@
 use super::action::Action;
 use super::direction::Direction;
 use super::field_of_play::FieldOfPlay;
-use log::{debug, error, info};
+use log::{debug, error};
 use rand::{thread_rng, Rng};
 
 #[derive(Clone, Default, Debug)]

--- a/src/models/stats.rs
+++ b/src/models/stats.rs
@@ -1,0 +1,72 @@
+use super::player::Player;
+use std::collections::HashMap;
+
+static GENERIC_VEC_ACCESS_PANIC_ERR_MSG: &str = "Invalid player name key for stats.";
+
+pub struct Stats {
+    field_x_len: usize,
+    field_y_len: usize,
+    number_of_turns: usize,
+    player_stats: HashMap<String, PlayerStats>
+}
+
+#[derive(Debug)]
+struct PlayerStats {
+    risk_tolerance: f64,
+    rounds_started_as_it: usize,
+    rounds_made_it: usize
+}
+
+impl Stats {
+    pub fn new(players: &Vec<Player>, number_of_turns: usize, field_x_len: usize, field_y_len: usize) -> Self {
+        let mut player_stats = HashMap::new();
+        players.iter().for_each(|player| {
+            player_stats.insert(
+                player.name.to_owned(),
+                PlayerStats {
+                    risk_tolerance: player.get_risk_tolerance(),
+                    rounds_started_as_it: 0,
+                    rounds_made_it: 0
+                }
+            );
+        });
+
+        Stats {
+            field_x_len,
+            field_y_len,
+            player_stats,
+            number_of_turns
+        }
+    }
+
+    pub fn record_start_player_details(&mut self, player: &Player) {
+        let player_stats = self
+            .player_stats
+            .get_mut(&player.name)
+            .expect(GENERIC_VEC_ACCESS_PANIC_ERR_MSG);
+        if player.is_it {
+            player_stats.rounds_started_as_it += 1;
+        }
+    }
+
+    pub fn record_new_it_details(&mut self, name: String) {
+        let player_stats = self
+            .player_stats
+            .get_mut(&name)
+            .expect(GENERIC_VEC_ACCESS_PANIC_ERR_MSG);
+        player_stats.rounds_made_it += 1;
+    }
+
+    pub fn output_stats_about_players(&self) {
+        println!(
+            "{} players played for {} turns on a field {} by {} large",
+            self.player_stats.keys().len(),
+            self.number_of_turns,
+            self.field_x_len,
+            self.field_y_len
+        );
+        self.player_stats.iter().for_each(|(name, stats_for_player)| {
+            println!("{}: {:?}", name, stats_for_player);
+        });
+    }
+}


### PR DESCRIPTION
In this PR:

- Attempt to improve player strategy by having non-it players prefer moving away from the it player.
- Add basic statistics to show details about a player's risk tolerance and how often they were tagged it.
- Make the number of turns non-infinite